### PR TITLE
Use plural, not datatypes.

### DIFF
--- a/editor/src/app/contents/fields/generic.js
+++ b/editor/src/app/contents/fields/generic.js
@@ -150,7 +150,7 @@ const fields = async () => {
       }
     },
     {
-      title: "featureList",
+      title: "features",
       label: "Feature List",
       type: "array",
       description: "a list of feature that the sw has",

--- a/editor/src/app/contents/fields/index.js
+++ b/editor/src/app/contents/fields/index.js
@@ -78,7 +78,7 @@ inputTypes
 outputTypes
 platforms
 usedBy
-summary_featureList
+summary_features
 summary_freeTags
 
 ------------------------------------

--- a/editor/src/app/editor_generator_schema.json
+++ b/editor/src/app/editor_generator_schema.json
@@ -544,9 +544,9 @@
             "type": "string"
           }
         },
-        "featureList": {
+        "features": {
           "type": "array",
-          "title": "featureList",
+          "title": "features",
           "description": "a list of feature that the sw has",
           "items": {
             "type": "string",

--- a/editor/src/app/yaml_validation_schema.json
+++ b/editor/src/app/yaml_validation_schema.json
@@ -5607,9 +5607,9 @@
             "type": "string"
           }
         },
-        "featureList": {
+        "features": {
           "type": "array",
-          "title": "featureList",
+          "title": "features",
           "description": "a list of feature that the sw has",
           "items": {
             "type": "string",

--- a/version/development/example/publiccode.minimal.yml
+++ b/version/development/example/publiccode.minimal.yml
@@ -28,7 +28,7 @@ description:
           is and why one should need it. We can potentially
           have many pages of text here.
 
-    featureList:
+    features:
        - Just one feature
 
 legal:

--- a/version/development/example/publiccode.yml
+++ b/version/development/example/publiccode.yml
@@ -67,7 +67,7 @@ description:
     freeTags:
        - an-english-tag
 
-    featureList:
+    features:
        - Very important feature
        - Will run without a problem
        - Has zero bugs

--- a/version/development/schema.md
+++ b/version/development/schema.md
@@ -414,7 +414,7 @@ Each tag must be in Unicode lowercase, and should not contain
 any Unicode whitespace character. The suggested character to
 separate multiple words is `-` (single dash).
 
-### Key `description/[lang]/featureList`
+### Key `description/[lang]/features`
 
 * Type: array of strings
 * Presence: mandatory (for at least one language)


### PR DESCRIPTION
## This PR

replace datatypes (eg. xxxList) with plurals (eg: xxx's')