### PR TITLE
Inserting BCP47 language tag

### DIFF
--- a/docs/en/example/publiccode.minimal.yml
+++ b/docs/en/example/publiccode.minimal.yml
@@ -15,7 +15,7 @@ developmentStatus: development
 softwareType: "standalone"
 
 description:
-  eng:
+  en:
     localisedName: medusa   # Optional
     genericName: Text Editor
     shortDescription: >
@@ -43,4 +43,4 @@ maintenance:
 localisation:
   localisationReady: yes
   availableLanguages:
-    - eng
+    - en

--- a/docs/en/example/publiccode.yml
+++ b/docs/en/example/publiccode.yml
@@ -47,7 +47,7 @@ intendedAudience:
     - us
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     genericName: Text Editor
     shortDescription: >
@@ -104,10 +104,10 @@ maintenance:
 localisation:
   localisationReady: yes
   availableLanguages:
-    - eng
-    - ita
-    - fra
-    - deu
+    - en
+    - it
+    - fr
+    - de
 
 dependsOn:
   open:

--- a/docs/en/schema.rst
+++ b/docs/en/schema.rst
@@ -370,10 +370,10 @@ software.
 
 **Note:** since all the strings contained in this section are
 user-visible and written in a specific language, you **must** specify
-the language you are editing the text in (using the IETF BCP 47 specifications
-`BCP47 <https://tools.ietf.org/html/bcp47>`__) by
+the language you are editing the text in (using the IETF 
+`BCP 47 <https://tools.ietf.org/html/bcp47>`__ specifications) by
 creating a sub-section with that name. The primary language subtag cannot be
-omitted, as mandated by the BCP47.  
+omitted, as mandated by the BCP 47.  
 
 An example for English:
 
@@ -719,7 +719,7 @@ Key ``localisation/availableLanguages``
 If present, this is the list of languages in which the software is
 available. Of course, this list will contain at least one language.
 The primary language subtag cannot be omitted, as mandated by the 
-`BCP47 <https://tools.ietf.org/html/bcp47>`__.
+`BCP 47 <https://tools.ietf.org/html/bcp47>`__.
 
 Section ``dependsOn``
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/en/schema.rst
+++ b/docs/en/schema.rst
@@ -711,12 +711,13 @@ than one language.
 Key ``localisation/availableLanguages``
 '''''''''''''''''''''''''''''''''''''''
 
--  Type: list of `ISO 639-2 <https://en.wikipedia.org/wiki/ISO_639-2>`__
-   alpha-3 codes
+-  Type: list of IETF BCP 47 language tags
 -  Presence: mandatory
 
 If present, this is the list of languages in which the software is
 available. Of course, this list will contain at least one language.
+The primary language subtag cannot be omitted, as mandated by the 
+`BCP47 <https://tools.ietf.org/html/bcp47>`__.
 
 Section ``dependsOn``
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/en/schema.rst
+++ b/docs/en/schema.rst
@@ -375,7 +375,7 @@ the language you are editing the text in (using the IETF BCP 47 specifications
 creating a sub-section with that name. The primary language subtag cannot be
 omitted, as mandated by the BCP47.  
 
-For example:
+An example for English:
 
 .. code:: yaml 
 

--- a/docs/en/schema.rst
+++ b/docs/en/schema.rst
@@ -372,7 +372,9 @@ software.
 user-visible and written in a specific language, you **must** specify
 the language you are editing the text in (using the IETF BCP 47 specifications
 `BCP47 <https://tools.ietf.org/html/bcp47>`__) by
-creating a sub-section with that name.
+creating a sub-section with that name. The primary language subtag cannot be
+omitted, as mandated by the BCP47.  
+
 For example:
 
 .. code:: yaml 

--- a/docs/en/schema.rst
+++ b/docs/en/schema.rst
@@ -370,16 +370,15 @@ software.
 
 **Note:** since all the strings contained in this section are
 user-visible and written in a specific language, you **must** specify
-the language you are editing the text in (using `ISO
-639-2 <https://en.wikipedia.org/wiki/ISO_639-2>`__ alpha-3 codes) by
+the language you are editing the text in (using the IETF BCP 47 specifications
+`BCP47 <https://tools.ietf.org/html/bcp47>`__) by
 creating a sub-section with that name.
-
-An example for English:
+For example:
 
 .. code:: yaml 
 
    description:
-     eng:
+     en:
        shortDescription: ...
        longDescription: ...
 

--- a/docs/en/schema.rst
+++ b/docs/en/schema.rst
@@ -713,6 +713,7 @@ Key ``localisation/availableLanguages``
 
 -  Type: list of IETF BCP 47 language tags
 -  Presence: mandatory
+-  Example: ``"it"``, ``"en"``, ``"sl-IT-nedis"``
 
 If present, this is the list of languages in which the software is
 available. Of course, this list will contain at least one language.

--- a/docs/it/example/publiccode.minimal.yml
+++ b/docs/it/example/publiccode.minimal.yml
@@ -15,7 +15,7 @@ developmentStatus: development
 softwareType: "standalone"
 
 description:
-  eng:
+  en:
     localisedName: medusa   # Optional
     genericName: Text Editor
     shortDescription: >
@@ -43,4 +43,4 @@ maintenance:
 localisation:
   localisationReady: yes
   availableLanguages:
-    - eng
+    - en

--- a/docs/it/example/publiccode.yml
+++ b/docs/it/example/publiccode.yml
@@ -47,7 +47,7 @@ intendedAudience:
     - us
 
 description:
-  eng:
+  en:
     localisedName: Medusa
     genericName: Text Editor
     shortDescription: >
@@ -104,10 +104,10 @@ maintenance:
 localisation:
   localisationReady: yes
   availableLanguages:
-    - eng
-    - ita
-    - fra
-    - deu
+    - en
+    - it
+    - fr
+    - de
 
 dependsOn:
   open:

--- a/docs/it/schema.rst
+++ b/docs/it/schema.rst
@@ -359,16 +359,17 @@ descriva il software.
 **Nota bene:** siccome tutte le stringhe contenute in questa sezione sono
 visibili all’utente e scritte in un linguaggio specifico, è
 **necessario** specificare il linguaggio con il quale si sta modificando
-il testo (usando i codici `ISO
-639-2 <https://en.wikipedia.org/wiki/ISO_639-2>`__ alpha-3) creando una
-sezione con quel nome.
+il testo. Per farlo è necessario creare una sezione dedicata al linguaggio
+seguendo le specifiche IETF `BCP 47 <https://tools.ietf.org/html/bcp47>`__. Si
+ricorda che il *primary language
+subtag* non può essere omesso, come specificato nel BCP 47. 
 
 Un esempio per l’italiano:
 
 .. code:: .yaml
 
    description:
-     ita:
+     it:
        shortDescription: ...
        longDescription: ...
 
@@ -721,12 +722,14 @@ disponibili si veda la chiave ``localisation/availableLanguages``.
 Chiave ``localisation/availableLanguages``
 ''''''''''''''''''''''''''''''''''''''''''
 
--  Tipo: lista di codici `ISO
-   639-2 <https://en.wikipedia.org/wiki/ISO_639-2>`__ alpha-3
+-  Tipo: lista di *language tag* secondo IETF BCP 47
 -  Presenza: obbligatoria
+-  Esempio: ``"it"``, ``"en"``, ``"sl-IT-nedis"``
 
 Se presente, questa è la lista di lingue in cui è disponibile il
 software. Ovviamente, questa lista dovrà contenere almeno una lingua.
+Si ricorda che il *primary language subtag* non può essere omesso, come
+specificato dal `BCP 47 <https://tools.ietf.org/html/bcp47>`__.
 
 Sezione ``dependsOn``
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/it/schema.rst
+++ b/docs/it/schema.rst
@@ -722,7 +722,7 @@ disponibili si veda la chiave ``localisation/availableLanguages``.
 Chiave ``localisation/availableLanguages``
 ''''''''''''''''''''''''''''''''''''''''''
 
--  Tipo: lista di *language tag* secondo IETF BCP 47
+-  Tipo: lista di *language tag* secondo le specifiche IETF BCP 47
 -  Presenza: obbligatoria
 -  Esempio: ``"it"``, ``"en"``, ``"sl-IT-nedis"``
 

--- a/docs/it/schema.rst
+++ b/docs/it/schema.rst
@@ -359,7 +359,7 @@ descriva il software.
 **Nota bene:** siccome tutte le stringhe contenute in questa sezione sono
 visibili all’utente e scritte in un linguaggio specifico, è
 **necessario** specificare il linguaggio con il quale si sta modificando
-il testo. Per farlo è necessario creare una sezione dedicata al linguaggio
+il testo. Per farlo è necessario creare una sezione dedicata alla lingua
 seguendo le specifiche IETF `BCP 47 <https://tools.ietf.org/html/bcp47>`__. Si
 ricorda che il *primary language
 subtag* non può essere omesso, come specificato nel BCP 47. 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -7,4 +7,5 @@
 - [ ] Ensure your files are written following RST specs (*not MD!*)
 - [ ] Italian version
 - [ ] English version
+- [ ] Example files 
 - [ ] Ask for review


### PR DESCRIPTION
## Title
Inserting BCP47 language tag
## Content
Substituting the ISO 639 lang tag for its superset, BCP47. The related issue is #2 .
## Review

- [x] Ensure your files are written following RST specs (*not MD!*)
- [x] Italian version
- [x] English version
- [x] Example files
- [x] Ask for review
