### PR TITLE
Release core-0.2/it-0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,27 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [core-0.2/it-0.2] - 2019-03-13
+### Added
+- A new `piattaforme` section has been created to group the platforms inside of
+  it.
+
+### Changed
+- The `conforme/accessibile` key becomes `conforme/lineeGuidaDesign` since it
+  is more self-explanatory.
+- The `conforme/interoperabile` key becomes `conforme/modelloInteroperabilita`
+  since it is more self-explanatory.
+- The `conforme/sicuro` key becomes `conforme/misureMinimeSicurezza` since
+  before it was rather vague and incomplete.
+- The `conforme/privacy` key becomes `conforme/gdpr` since the `privacy` term
+  is quite vague and incomplete.
+
+### Removed
+- The `ecosistemi` key has been removed since its values are already present in
+  the `intendedAudience/scope` key.
+- The `designKit` section has been removed since we will track the design kits
+  usages by means of the crawler.
+
 ## [core-0.2] - 2019-03-11
 ### Added
 - A new `countryExtensionVersion` key was added under each country-specific extension, in order to separate their versioning from the core.
@@ -11,7 +32,7 @@ All notable changes to this project will be documented in this file.
 - `tags` was replaced by `categories` (with a different dictionary of values).
 - BCP47 is now used for languages instead of ISO 639-2, thus keys under `description` will now look like `en` instead of `eng`
 - `publiccode-yaml-version` was moved to `publiccodeYmlVersion` using camelCase
-- `maintainance/contacts` is now mandatory only if `maintainance/type` is `internal` or `community`.
+- `maintenance/contacts` is now mandatory only if `maintenance/type` is `internal` or `community`.
 - All files ported to RST from previous MD
 
 ### Removed

--- a/README.it.md
+++ b/README.it.md
@@ -1,33 +1,37 @@
 # Lo Standard `publiccode.yml`
 
+[![GitHub release](https://img.shields.io/github/release/italia/publiccode.yml.svg?style=plastic)](https://github.com/italia/publiccode.yml/releases)
+[![Join the #publiccode channel](https://img.shields.io/badge/Slack%20channel-%23publiccode-blue.svg)](https://developersitalia.slack.com/messages/CAM3F785T)
+[![Get invited](https://slack.developers.italia.it/badge.svg)](https://slack.developers.italia.it/)
+[![Docs
+Italia](https://docs.italia.it/media/static/projects/badges/passing.svg)](https://docs.italia.it/italia/developers-italia/publiccodeyml/it/master/index.html)
+[![Documentation](https://img.shields.io/badge/Documentation-Docs%20Italia-blue.svg)](https://docs.italia.it/italia/developers-italia/publiccodeyml/it/master/index.html)
+
+> Uno standard di descrizione di metadati per software pubblico 
+
+*Read this in [English](README.md).*
+
+---
+
+## Table of Contents
+
+- [Descrizione](#descrizione)
+- [A cosa serve questo file](#a-cosa-serve-questo-file)
+- [Documentazione](#documentazione)
+- [Trovare progetti](#la-ricerca-dei-progetti)
+- [Versioning](#versioning)
+- [Contributing](#come-contribuire)
+- [Autori](#autori)
+- [License](#license)
+
+## Descrizione
+
 `publiccode.yml` è uno standard di metadati adatto a repository
 di software pubblico e di policy. Questo standard ha lo scopo
 di rendere il software sviluppato dalle Pubbliche Amministrazioni e Pubbliche
 Organizzazioni facile da individuare e, di conseguenza, riutilizzare. Proprio
 per questo motivo, è stato pensato per essere semplice da adottare sia per gli
 sviluppatori che per i non addetti ai lavori. 
-
-## Versioni
-
-**Ultimo rilascio: [Versione
-0.1](https://github.com/italia/publiccode.yml/releases/latest)**
-
-[Vedi tutte le versioni](https://github.com/italia/publiccode.yml/releases)
-
-Questo progetto aderisce al modello di versioning [*Semantic
-Versioning*](https://semver.org/).
-
-Inoltre, questo progetto usa i *branch* e i *tag* di git nel seguente modo:
-* il branch `master` contiene l'ultima versione stabile dello standard;
-* il branch `development` contiene gli aggiornamenti proposti e in discussione
-  per la prossima versione dello standard;
-* La [release page](https://github.com/italia/publiccode.yml/releases) di
-  GitHub contiene tutte le versioni rilasciate dello standard. Le *release*
-  sono effettuate seguendo il nome del tag per questioni di coerenza (ad es.,
-  il tag `v0.1` implica una release denominata `v0.1`). 
-
-Le specifiche `publiccode.yml` sono sviluppate dal [Team per la Trasformazione
-Digitale](https://teamdigitale.governo.it) e dagli [Autori](AUTHORS.md).
 
 ## A cosa serve questo file
 
@@ -56,6 +60,14 @@ Il formato del file `publiccode.yml` è pensato per essere facilmente aggiunto
 ad ogni nuovo progetto e potrà cambiare ed adattarsi ai cambiamenti rispetto al
 contesto nel quale è stato originariamente sviluppato. 
 
+## Documentazione
+
+Questo repository è strutturato per essere compatibile con [Docs Italia](https://docs.italia.it/italia/developers-italia/publiccodeyml/it/master/index.html).
+Per questo motivo, il contenuto delle rilevanti cartelle sarà compilato
+e renderizzato all'interno di tale piattaforma. `Docs Italia` è progettato per
+supportare un documento localizzato in diverse lingue e per questo motivo è la
+piattaforma di riferimento per visualizzare questo standard.
+
 ## La ricerca dei progetti
 
 La ricerca dei progetti dipende da come le API sono state strutturate per ogni
@@ -70,10 +82,41 @@ Il Team per la Trasformazione Digitale sta anche lavorando per fornire uno
 scanner che cerchi tutti i file `publiccode.yml` su tutti i siti accessibili
 pubblicamente, per poi pubblicarli sotto forma di open data. 
 
+## Versioning
+
+**Ultimo rilascio:** [![GitHub release](https://img.shields.io/github/release/italia/publiccode.yml.svg?style=plastic)](https://github.com/italia/publiccode.yml/releases) [See all versions](https://github.com/italia/publiccode.yml/releases)
+
+[Vedi tutte le versioni](https://github.com/italia/publiccode.yml/releases)
+
+Questo progetto aderisce al modello di versioning [*Semantic
+Versioning*](https://semver.org/).
+
+Inoltre, questo progetto usa i *branch* e i *tag* di git nel seguente modo:
+* il branch `master` contiene l'ultima versione stabile dello standard;
+* il branch `development` contiene gli aggiornamenti proposti e in discussione
+  per la prossima versione dello standard;
+* La [release page](https://github.com/italia/publiccode.yml/releases) di
+  GitHub contiene tutte le versioni rilasciate dello standard. Le *release*
+  sono effettuate seguendo il nome del tag per questioni di coerenza.
+
+Siccome questo repository contiene sia lo schema `core` che quelli contenenti
+le estensioni per ogni paese, è necessario adottare una strategia di versioning
+più raffinata. Per questo motivo, ogni update al core e/o ad un'estensione
+specifica per Paese, sarà taggata come segue:
+
+> core-x.y.z/cc-a.b.c
+
+dove cc rappresenta il codice del paese presente nella chiave
+`countryExtensionVersion` dello schema modificato. 
+
 ## Come contribuire 
 
 Sentitevi liberi di aprire delle [Pull Requests e di presentare un problema
 con una Issues](CONTRIBUTING.md).
+
+## Autori
+Le specifiche `publiccode.yml` sono sviluppate dal [Team per la Trasformazione
+Digitale](https://teamdigitale.governo.it) e dagli [Autori](AUTHORS.md).
 
 ## Licenza
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Italia](https://docs.italia.it/media/static/projects/badges/passing.svg)](https:
 
 > A metadata description standard for public software
 
+*Leggi questo documento in [Italiano](README.it.md)*
+
 ---
 
 ## Table of Contents
@@ -97,10 +99,9 @@ country-specific ones, it is necessary to further refine the versioning.
 As such, each update at the core and/or to a country-specific extension will be
 tagged as follows:
 
-> core:x.y.z/<cc>:a.b.c
+> core-x.y.z/cc-a.b.c
 
-where <cc> is the country code defined using one of the ISO 3166-1 alpha-2
-codes. 
+where cc is the country code defined in the `countryExtensionVersion` key. 
 
 This versioning schema is fundamental in this project since the
 `publiccode.yml` file contains references to the core release in the

--- a/docs/en/example/publiccode.minimal.yml
+++ b/docs/en/example/publiccode.minimal.yml
@@ -1,4 +1,4 @@
-publiccodeYmlVersion: "0.1"
+publiccodeYmlVersion: "0.2"
 
 name: Medusa
 url: "https://example.com/italia/medusa.git"

--- a/docs/en/example/publiccode.yml
+++ b/docs/en/example/publiccode.yml
@@ -1,4 +1,4 @@
-publiccodeYmlVersion: "0.1"
+publiccodeYmlVersion: "0.2"
 
 name: Medusa
 applicationSuite: MegaProductivitySuite
@@ -120,27 +120,19 @@ dependsOn:
       optional: yes
 
 it:
-
-  countryExtensionVersion: 0.1
+  countryExtensionVersion: "0.1"
 
   conforme:
-    accessibile: yes
-    interoperabile: yes
-    sicuro: yes
-    privacy: yes
+    lineeGuidaDesign: yes
+    modelloInteroperabilita: yes
+    misureMinimeSicurezza: yes
+    gdpr: yes
+
+  piattaforme:
+    spid: yes
+    cie: yes
+    anpr: yes
+    pagopa: yes
 
   riuso:
     codiceIPA: c_h501
-
-  spid: yes
-  pagopa: yes
-  cie: yes
-  anpr: yes
-  ecosistemi:
-    - scuola
-
-  designKit:
-    seo: no
-    ui: yes
-    web: yes
-    content: no

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -1,18 +1,30 @@
 ``publiccode.yml``
 ==================
 
-``publiccode.yml`` is a metadata standard for repositories containing software developed or acquired by the Public Administration, aimed at making them easily discoverabile and thus reusable by other entities.
+``publiccode.yml`` is a metadata standard for repositories containing software
+developed or acquired by the Public Administration, aimed at making them easily
+discoverabile and thus reusable by other entities.
 
-By including a ``publiccode.yml`` file in the root of a repository, and populating it with information about the software, technicians and civil servants can evaluate it. Automatic indexing tools can also be built, since the format is easily readable by both humans and machines.
+By including a ``publiccode.yml`` file in the root of a repository, and
+populating it with information about the software, technicians and civil
+servants can evaluate it. Automatic indexing tools can also be built, since the
+format is easily readable by both humans and machines.
 
-``publiccode.yml`` is mandatory for all public software developed in Italy, according to the national `guidelines <https://docs.italia.it/AgID/linee-guida-riuso-software/lg-acquisizione-e-riuso-software-per-pa-docs/>`__: this enables the Developers Italia crawler to build the national `software catalog <https://developers.italia.it/>`__. The standard is designed to be interoperable internationally, thus the country-specific keys are separated by the core part and are defined in specific sections that each government can rule.
+``publiccode.yml`` is mandatory for all public software developed in Italy,
+according to the national `guidelines
+<https://docs.italia.it/AgID/linee-guida-riuso-software/lg-acquisizione-e-riuso-software-per-pa-docs/>`__:
+this enables the Developers Italia crawler to build the national `software
+catalog <https://developers.italia.it/>`__. The standard is designed to be
+interoperable internationally, thus the country-specific keys are separated by
+the core part and are defined in specific sections that each government can
+rule.
 
 Details carried by a ``publiccode.yml`` file include: 
 
 - title and description of the project or product (in one or more languages); 
 - development state (e.g., ``concept``, ``development``, ``beta``, ``stable``, ``obsolete``; 
 - contacts of the entity who published the codebase; 
-- contacts of the maintainer, if any, including the expire date of the maintainance contract; 
+- contacts of the maintainer, if any, including the expire date of the maintenance contract; 
 - information about the legal context for which the project or product was designed; 
 - dependencies.
   
@@ -32,11 +44,10 @@ Table of contents
    :maxdepth: 2
    :numbered:
 
-   intro.rst
-   schema.rst
+   schema.core.rst
+   schema.it.rst
    country.rst
    forks.rst
    categories-list.rst
    scope-list.rst
-   tools.rst
    example.rst

--- a/docs/en/schema.core.rst
+++ b/docs/en/schema.core.rst
@@ -244,6 +244,7 @@ Key ``developmentStatus``
    ``obsolete``
 
 The keys are: 
+
 -  ``concept`` - The software is just a “concept”. No
    actual code may have been produced, and the repository could simply be a
    placeholder. 
@@ -616,7 +617,7 @@ Key ``maintenance/contractors``
 '''''''''''''''''''''''''''''''
 
 -  Type: array of Contractor (see below)
--  Presence: mandatory (if ``maintainance/type`` **is** ``contract``)
+-  Presence: mandatory (if ``maintenance/type`` **is** ``contract``)
 
 This key describes the entity or entities, if any, that are currently
 contracted for maintaining the software. They can be companies,
@@ -626,7 +627,7 @@ Key ``maintenance/contacts``
 ''''''''''''''''''''''''''''
 
 -  Type: List of Contacts (see below)
--  Presence: mandatory (if ``maintainance/type`` **is** ``internal`` or ``community``)
+-  Presence: mandatory (if ``maintenance/type`` **is** ``internal`` or ``community``)
 
 One or more contacts maintaining this software.
 

--- a/docs/en/schema.it.rst
+++ b/docs/en/schema.it.rst
@@ -1,1 +1,133 @@
-Placeholder for `schema.it.md <../it/schema.it.md>`__.
+.. _italian-extensions:
+
+Italy
+-----
+
+All the extensions listed below are specific for Italy and, as such, they must
+be inserted in a section named with the ``it`` code. Every Country is specified
+using a two letters *country code* following the ISO 3166-1 alpha-2 standard.
+
+
+Key ``countryExtensionVersion``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Type: string
+- Presence: mandatory
+- Example: ``"1.0"``
+
+
+This key specifies the version to which the current extension schema adheres to,
+for forward compatibility.
+
+Please note how the value of this key is independent from the top-level
+``publiccodeYmlVersion`` one (see :ref:`core`). In such a way, the extensions
+schema versioning is independent both from the core version of the schema and
+from every other Country.
+
+Key ``conforme``
+~~~~~~~~~~~~~~~~
+
+This section contains the keys for auto-declaring the compliance with the
+current legislation, with respect to the following sections.
+Not including these keys implies that the compliance is not known or not
+declared.
+
+Key ``conforme/lineeGuidaDesign``
+'''''''''''''''''''''''''''''''''
+
+- Type: boolean
+- Presence: optional
+
+If present and set to ``yes``, the software is compliant with the Italian accessibility
+laws (L. 4/2004), as further explained in the 
+`linee guida di
+design <https://docs.italia.it/italia/designers-italia/design-linee-guida-docs>`__ (Italian language).
+
+Key ``conforme/modelloInteroperatibilita``
+''''''''''''''''''''''''''''''''''''''''''
+
+- Type: boolean
+- Presence: optional
+
+If present and set to ``yes``, the software is compliant with the `linee
+guida
+sull’interoperabilità <https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs>`__.
+
+Regulatory reference: `Art. 73 del
+CAD <https://docs.italia.it/italia/piano-triennale-ict/codice-amministrazione-digitale-docs/it/v2017-12-13/_rst/capo8_art73.html>`__ (Italian language).
+
+
+Key ``conforme/misureMinimeSicurezza``
+''''''''''''''''''''''''''''''''''''''
+
+- Type: boolean
+- Presence: optional
+
+If present and set to ``yes``, the software is compliant with the `Misure
+minime di sicurezza ICT per le Pubbliche
+amministrazioni <http://www.agid.gov.it/sites/default/files/documentazione/misure_minime_di_sicurezza_v.1.0.pdf>`__ (Italian language). 
+
+
+Key ``conforme/gdpr``
+'''''''''''''''''''''
+
+- Type: boolean
+- Presence: optional
+
+If present and set to ``yes``, the software respects the GDPR.
+
+
+Section ``piattaforme``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Key ``spid``
+''''''''''''
+
+- Type: boolean
+- Presence: optional
+
+
+If present and set to ``yes``, the software interfaces with `SPID
+- il Sistema Pubblico di Identità
+Digitale <https://developers.italia.it/it/spid>`__.
+
+Key ``cie``
+'''''''''''
+
+- Type: boolean
+- Presence: optional
+
+If present and set to ``yes``, the software interfaces with the Italian
+electronic ID card (``Carta di Identità Elettronica``).
+
+Key ``anpr``
+''''''''''''
+
+- Type: boolean
+- Presence: optional
+
+If present and set to ``yes``, the software interfaces with ANPR.
+
+Key ``pagopa``
+''''''''''''
+
+- Type: boolean
+- Presence: optional
+
+If present and set to ``yes``, the software interfaces with pagoPA.
+
+Section ``riuso``
+~~~~~~~~~~~~~~~~~
+
+This section contains a set of keys related to the publication of the software
+inside the reuse catalog of `Developers Italia <https://developers.italia.it>`__.
+
+Chiave ``riuso/codiceIPA``
+''''''''''''''''''''''''''
+
+-  Type: string (iPA code) 
+-  Presence: mandatory if ``repoOwner`` is a Public Administration 
+-  Example: ``c_h501``
+
+This key represents the administration code inside the Public Administration
+index (codice IPA).

--- a/docs/it/example/publiccode.minimal.yml
+++ b/docs/it/example/publiccode.minimal.yml
@@ -1,4 +1,4 @@
-publiccodeYmlVersion: "0.1"
+publiccodeYmlVersion: "0.2"
 
 name: Medusa
 url: "https://example.com/italia/medusa.git"

--- a/docs/it/example/publiccode.yml
+++ b/docs/it/example/publiccode.yml
@@ -1,4 +1,4 @@
-publiccodeYmlVersion: "0.1"
+publiccodeYmlVersion: "0.2"
 
 name: Medusa
 applicationSuite: MegaProductivitySuite
@@ -120,27 +120,19 @@ dependsOn:
       optional: yes
 
 it:
-
-  countryExtensionVersion: 0.1
+  countryExtensionVersion: "0.1"
 
   conforme:
-    accessibile: yes
-    interoperabile: yes
-    sicuro: yes
-    privacy: yes
+    lineeGuidaDesign: yes
+    modelloInteroperabilita: yes
+    misureMinimeSicurezza: yes
+    gdpr: yes
+
+  piattaforme:
+    spid: yes
+    cie: yes
+    anpr: yes
+    pagopa: yes
 
   riuso:
     codiceIPA: c_h501
-
-  spid: yes
-  pagopa: yes
-  cie: yes
-  anpr: yes
-  ecosistemi:
-    - scuola
-
-  designKit:
-    seo: no
-    ui: yes
-    web: yes
-    content: no

--- a/docs/it/index.rst
+++ b/docs/it/index.rst
@@ -1,12 +1,25 @@
 Lo Standard ``publiccode.yml``
 ==============================
 
-``publiccode.yml`` è uno standard di metadati ideato per essere inserito in repository contenenti software della Pubblica Amministrazione con lo scopo di renderli facilmente individuabili e, di
-conseguenza, riutilizzabili da altri enti.
+``publiccode.yml`` è uno standard di metadati ideato per essere inserito in
+repository contenenti software della Pubblica Amministrazione con lo scopo di
+renderli facilmente individuabili e, di conseguenza, riutilizzabili da altri
+enti.
 
-Inserendo nella root di un repository un file chiamato ``publiccode.yml`` che descrive le caratteristiche del software se ne agevola la comprensione ai tecnici e ai decisori pubblici interessati a valutarlo; al tempo stesso si permette di costruire strumenti automatici di indicizzazione, poiché il formato è facilmente leggibile sia da esseri umani sia da macchine.
+Inserendo nella root di un repository un file chiamato ``publiccode.yml`` che
+descrive le caratteristiche del software se ne agevola la comprensione ai
+tecnici e ai decisori pubblici interessati a valutarlo; al tempo stesso si
+permette di costruire strumenti automatici di indicizzazione, poiché il formato
+è facilmente leggibile sia da esseri umani sia da macchine.
 
-``publiccode.yml`` è obbligatorio per tutto il software pubblico sviluppato in Italia, come da `linee guida <https://docs.italia.it/AgID/linee-guida-riuso-software/lg-acquisizione-e-riuso-software-per-pa-docs/>`__: questo consente al crawler automatico di Developers Italia di costituire il `catalogo del software a riuso <https://developers.italia.it/>`__. Lo standard è tuttavia pensato in ottica internazionale, per cui tutte le specificità nazionali sono separate dal core e definite in apposite sezioni estensibili autonomamente dai governi nazionali.
+``publiccode.yml`` è obbligatorio per tutto il software pubblico sviluppato in
+Italia, come da `linee guida
+<https://docs.italia.it/AgID/linee-guida-riuso-software/lg-acquisizione-e-riuso-software-per-pa-docs/>`__:
+questo consente al crawler automatico di Developers Italia di costituire il
+`catalogo del software a riuso <https://developers.italia.it/>`__. Lo standard
+è tuttavia pensato in ottica internazionale, per cui tutte le specificità
+nazionali sono separate dal core e definite in apposite sezioni estensibili
+autonomamente dai governi nazionali.
 
 Tra le informazioni contenute in un ``publiccode.yml`` vi sono: 
 
@@ -32,7 +45,8 @@ Indice dei contenuti
    :maxdepth: 2
    :numbered:
 
-   schema.rst
+   schema.core.rst
+   schema.it.rst
    country.rst 
    forks.rst
    categories-list.rst

--- a/docs/it/schema.core.rst
+++ b/docs/it/schema.core.rst
@@ -361,7 +361,7 @@ subtag* non può essere omesso, come specificato nel BCP 47.
 
 Un esempio per l’italiano:
 
-.. code:: .yaml
+.. code:: yaml
 
    description:
      it:
@@ -548,7 +548,9 @@ essere usati per dare una rapida panoramica sull’aspetto e le
 funzionalità del software. I video devono essere ospitati su una
 piattaforma di video sharing che supporti lo standard
 `oEmbed <https://oembed.com>`__; le opzioni più popolari sono YouTube e
-Vimeo. **Nota bene:** dal momento che costituisce parte integrante della
+Vimeo. 
+
+**Nota bene:** dal momento che costituisce parte integrante della
 documentazione, è opportuno che il video sia pubblicato con una licenza
 aperta.
 
@@ -653,7 +655,7 @@ Chiave ``maintenance/contractors``
 ''''''''''''''''''''''''''''''''''
 
 -  Tipo: array di Contractor (vedi sotto)
--  Presenza: obbligatoria (se ``maintainance/type`` **è** ``contract``)
+-  Presenza: obbligatoria (se ``maintenance/type`` **è** ``contract``)
 
 Questa chiave descrive l’entità o le entità, se ce ne sono, che
 attualmente hanno un contratto di manutenzione del software. Queste
@@ -663,7 +665,7 @@ Chiave ``maintenance/contacts``
 '''''''''''''''''''''''''''''''
 
 -  Tipo: Lista di Contatti (vedi sotto)
--  Presenza: obbligatoria (se ``maintainance/type`` **è** ``internal`` oppure ``community``)
+-  Presenza: obbligatoria (se ``maintenance/type`` **è** ``internal`` oppure ``community``)
 
 Uno o più contatti di chi sta mantenendo il software.
 

--- a/docs/it/schema.it.rst
+++ b/docs/it/schema.it.rst
@@ -1,4 +1,4 @@
-.. _estensioni-italiane:
+.. _italian-extensions:
 
 Italia
 ------
@@ -10,7 +10,8 @@ seguendo lo standard ISO 3166-1 alpha-2.
 
 
 Chiave ``countryExtensionVersion``
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 -  Tipo: stringa
 -  Presenza: obbligatoria
 -  Esempio: ``"1.0"``
@@ -28,9 +29,11 @@ Sezione ``conforme``
 
 Questa sezione contiene delle chiavi per auto dichiarare la conformità
 con la normativa vigente, rispetto ad alcune sezioni.
+Se queste chiavi non vengono incluse, si intende che la conformità non è nota
+o non viene dichiarata.
 
-Chiave ``conforme/accessibile``
-'''''''''''''''''''''''''''''''
+Chiave ``conforme/lineeGuidaDesign``
+''''''''''''''''''''''''''''''''''''
 
 -  Tipo: booleano
 -  Presenza: opzionale
@@ -40,8 +43,8 @@ materia di accessibilità (L. 4/2004), come descritto ulteriormente nelle
 `linee guida di
 design <https://docs.italia.it/italia/designers-italia/design-linee-guida-docs>`__.
 
-Chiave ``conforme/interoperabile``
-''''''''''''''''''''''''''''''''''
+Chiave ``conforme/modelloInteroperabilita``
+'''''''''''''''''''''''''''''''''''''''''''
 
 -  Tipo: booleano
 -  Presenza: opzionale
@@ -53,8 +56,8 @@ sull’interoperabilità <https://docs.italia.it/italia/piano-triennale-ict/lg-m
 Riferimento normativo: `Art. 73 del
 CAD <https://docs.italia.it/italia/piano-triennale-ict/codice-amministrazione-digitale-docs/it/v2017-12-13/_rst/capo8_art73.html>`__.
 
-Chiave ``conforme/sicuro``
-''''''''''''''''''''''''''
+Chiave ``conforme/misureMinimeSicurezza``
+'''''''''''''''''''''''''''''''''''''''''
 
 -  Tipo: booleano
 -  Presenza: opzionale
@@ -63,18 +66,19 @@ Se presente e impostato a ``yes``, il software è conforme alle `Misure
 minime di sicurezza ICT per le Pubbliche
 amministrazioni <http://www.agid.gov.it/sites/default/files/documentazione/misure_minime_di_sicurezza_v.1.0.pdf>`__.
 
-Chiave ``conforme/privacy``
-'''''''''''''''''''''''''''
+Chiave ``conforme/gdpr``
+''''''''''''''''''''''''
 
 -  Tipo: booleano
 -  Presenza: opzionale
 
-Se presente e impostato a ``yes``, il software rispetta le `linee guida
-del Garante per la protezione dei dati
-personali <https://www.garanteprivacy.it/web/guest/home/docweb/-/docweb-display/docweb/1772725>`__.
+Se presente e impostato a ``yes``, il software rispetta il GDPR.
+
+Sezione ``piattaforme``
+~~~~~~~~~~~~~~~~~~~~~~~
 
 Chiave ``spid``
-~~~~~~~~~~~~~~~
+'''''''''''''''
 
 -  Tipo: booleano
 -  Presenza: opzionale
@@ -84,7 +88,7 @@ Se presente e impostato a ``yes``, il software si interfaccia con `SPID
 Digitale <https://developers.italia.it/it/spid>`__.
 
 Chiave ``cie``
-~~~~~~~~~~~~~~
+''''''''''''''
 
 -  Tipo: booleano
 -  Presenza: opzionale
@@ -93,7 +97,7 @@ Se presente e impostato a ``yes``, il software si interfaccia con la
 Carta di Identità Elettronica.
 
 Chiave ``anpr``
-~~~~~~~~~~~~~~~
+'''''''''''''''
 
 -  Tipo: booleano
 -  Presenza: opzionale
@@ -101,94 +105,27 @@ Chiave ``anpr``
 Se presente e impostato a ``yes``, il software si interfaccia con ANPR.
 
 Chiave ``pagopa``
-~~~~~~~~~~~~~~~~~
+'''''''''''''''''
 
 -  Tipo: booleano
 -  Presenza: opzionale
 
 Se presente e impostato a ``yes``, il software si interfaccia con
-PagoPA.
-
-Chiave ``ecosistemi``
-~~~~~~~~~~~~~~~~~~~~~
-
--  Tipo: lista enumerata
--  Presenza: opzionale
-
-L’elenco di `Ecosistemi del Piano
-Triennale <http://pianotriennale-ict.readthedocs.io/it/latest/doc/06_ecosistemi.html>`__
-per il quale il software è rilevante.
-
-L’elenco degli ecosistemi possibili è il seguente:
-
--  sanita
--  welfare
--  finanza-pubblica
--  scuola
--  istruzione-superiore-ricerca
--  difesa-sicurezza-soccorso-legalita
--  giustizia
--  infrastruttura-logistica
--  sviluppo-sostenibilita
--  beni-culturali-turismo
--  agricoltura
--  italia-europa-mondo
+pagoPA.
 
 Sezione ``riuso``
 ~~~~~~~~~~~~~~~~~
 
 Questa sezione contiene una serie di chiavi legate alla pubblicazione
-del software sul “`Catalogo del Riuso <https://developers.italia.it>`__”.
+del software sul `Catalogo del Riuso <https://developers.italia.it>`__.
 
 Chiave ``riuso/codiceIPA``
 ''''''''''''''''''''''''''
 
--  Tipo: stringa (codice IPA)
+-  Tipo: stringa (codice iPA)
 -  Presenza: obbligatoria se ``repoOwner`` è una Pubblica
    Amministrazione
 -  Esempio: ``c_h501``
 
 Questa chiave rappresenta il codice dell’amministrazione all’interno
 dell’Indice delle Pubbliche Amministrazioni (codice IPA).
-
-Sezione ``designKit``
-~~~~~~~~~~~~~~~~~~~~~
-
-Chiave ``designKit/seo``
-''''''''''''''''''''''''
-
--  Tipo: booleano
--  Presenza: opzionale
-
-Se presente e impostato a ``yes``, il software ha utilizzato, in fase di
-progettazione, il kit di SEO di `Designers
-Italia <https://docs.italia.it/italia/piano-triennale-ict/pianotriennale-ict-doc/it/stabile/doc/06_ecosistemi.html>`__.
-
-Chiave ``designKit/ui``
-'''''''''''''''''''''''
-
--  Tipo: booleano
--  Presenza: opzionale
-
-Se presente e impostato a ``yes``, il software ha utilizzato, in fase di
-progettazione, il kit UI di `Designers
-Italia <https://designers.italia.it>`__.
-
-Chiave ``designKit/web``
-''''''''''''''''''''''''
-
--  Tipo: booleano
--  Presenza: opzionale
-
-Se presente e impostato a ``yes``, il software utilizza il kit per lo
-sviluppo web di `Designers Italia <https://designers.italia.it>`__.
-
-Chiave ``designKit/content``
-''''''''''''''''''''''''''''
-
--  Tipo: booleano
--  Presenza: opzionale
-
-Se presente e impostato a ``yes``, il software ha utilizzato, in fase di
-progettazione, il kit per la scrittura del contenuto di `Designers
-Italia <https://designers.italia.it>`__.


### PR DESCRIPTION
## Title
This PR ports the Italian extensions to 0.2.
Relevant commits:
* feat: mods to the italian schema
* fix: removed designKit section
* add: changelog info
* add: English translation of the schema.it
* fix: maintainance -> maintenance
* ported examples to new version of schema
* port examples to core-0.2

## Review

- [x] Ensure your files are written following RST specs (*not MD!*)
- [x] Italian version
- [x] English version
- [x] Example files 
- [ ] Ask for review
