### PR TITLE
Switch boolean to true/false from yes/no

### DIFF
--- a/docs/en/country.rst
+++ b/docs/en/country.rst
@@ -22,7 +22,7 @@ If a software is compliant I will find:
    it:
      countryExtensionVersion: "0.2"
      piattaforme:
-      - spid: yes
+      - spid: true
 
 Notice that country-specific extensions within international sections
 are not allowed. Countries that want to extend the format should add a

--- a/docs/en/example/publiccode.minimal.yml
+++ b/docs/en/example/publiccode.minimal.yml
@@ -41,6 +41,6 @@ maintenance:
     - name: Francesco Rossi
 
 localisation:
-  localisationReady: yes
+  localisationReady: true
   availableLanguages:
     - en

--- a/docs/en/example/publiccode.yml
+++ b/docs/en/example/publiccode.yml
@@ -95,7 +95,7 @@ maintenance:
       phone: +39 231 13215112
 
 localisation:
-  localisationReady: yes
+  localisationReady: true
   availableLanguages:
     - en
     - it
@@ -107,32 +107,32 @@ dependsOn:
     - name: MySQL
       versionMin: "1.1"
       versionMax: "1.3"
-      optional: yes
+      optional: true
     - name: PostgreSQL
       version: "3.2"
-      optional: yes
+      optional: true
   proprietary:
     - name: Oracle
       versionMin: "11.4"
     - name: IBM SoftLayer
   hardware:
     - name: NFC Reader
-      optional: yes
+      optional: true
 
 it:
   countryExtensionVersion: "0.2"
 
   conforme:
-    lineeGuidaDesign: yes
-    modelloInteroperabilita: yes
-    misureMinimeSicurezza: yes
-    gdpr: yes
+    lineeGuidaDesign: true
+    modelloInteroperabilita: true
+    misureMinimeSicurezza: true
+    gdpr: true
 
   piattaforme:
-    spid: yes
-    cie: yes
-    anpr: yes
-    pagopa: yes
+    spid: true
+    cie: true
+    anpr: true
+    pagopa: true
 
   riuso:
     codiceIPA: c_h501

--- a/docs/en/schema.core.rst
+++ b/docs/en/schema.core.rst
@@ -654,7 +654,7 @@ Key ``localisation/localisationReady``
 -  Type: boolean
 -  Presence: mandatory
 
-If ``yes``, the software has infrastructure in place or is otherwise
+If ``true``, the software has infrastructure in place or is otherwise
 designed to be multilingual. It does not need to be available in more
 than one language.
 
@@ -738,7 +738,7 @@ compatibility matrix.
 
    - name: PostgreSQL
      version: "3.2"
-     optional: yes
+     optional: true
 
 This snippet marks an optional dependency on PostgreSQL exactly version
 3.2.

--- a/docs/en/schema.it.rst
+++ b/docs/en/schema.it.rst
@@ -38,7 +38,7 @@ Key ``conforme/lineeGuidaDesign``
 - Type: boolean
 - Presence: optional
 
-If present and set to ``yes``, the software is compliant with the Italian accessibility
+If present and set to ``true``, the software is compliant with the Italian accessibility
 laws (L. 4/2004), as further explained in the 
 `linee guida di
 design <https://docs.italia.it/italia/designers-italia/design-linee-guida-docs>`__ (Italian language).
@@ -49,7 +49,7 @@ Key ``conforme/modelloInteroperatibilita``
 - Type: boolean
 - Presence: optional
 
-If present and set to ``yes``, the software is compliant with the `linee
+If present and set to ``true``, the software is compliant with the `linee
 guida
 sull’interoperabilità <https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs>`__.
 
@@ -63,7 +63,7 @@ Key ``conforme/misureMinimeSicurezza``
 - Type: boolean
 - Presence: optional
 
-If present and set to ``yes``, the software is compliant with the `Misure
+If present and set to ``true``, the software is compliant with the `Misure
 minime di sicurezza ICT per le Pubbliche
 amministrazioni <http://www.agid.gov.it/sites/default/files/documentazione/misure_minime_di_sicurezza_v.1.0.pdf>`__ (Italian language). 
 
@@ -74,7 +74,7 @@ Key ``conforme/gdpr``
 - Type: boolean
 - Presence: optional
 
-If present and set to ``yes``, the software respects the GDPR.
+If present and set to ``true``, the software respects the GDPR.
 
 
 Section ``piattaforme``
@@ -87,7 +87,7 @@ Key ``piattaforme/spid``
 - Presence: optional
 
 
-If present and set to ``yes``, the software interfaces with `SPID
+If present and set to ``true``, the software interfaces with `SPID
 - il Sistema Pubblico di Identità
 Digitale <https://developers.italia.it/it/spid>`__.
 
@@ -97,7 +97,7 @@ Key ``piattaforme/cie``
 - Type: boolean
 - Presence: optional
 
-If present and set to ``yes``, the software interfaces with the Italian
+If present and set to ``true``, the software interfaces with the Italian
 electronic ID card (``Carta di Identità Elettronica``).
 
 Key ``piattaforme/anpr``
@@ -106,7 +106,7 @@ Key ``piattaforme/anpr``
 - Type: boolean
 - Presence: optional
 
-If present and set to ``yes``, the software interfaces with ANPR.
+If present and set to ``true``, the software interfaces with ANPR.
 
 Key ``piattafome/pagopa``
 '''''''''''''''''''''''''
@@ -114,7 +114,7 @@ Key ``piattafome/pagopa``
 - Type: boolean
 - Presence: optional
 
-If present and set to ``yes``, the software interfaces with pagoPA.
+If present and set to ``true``, the software interfaces with pagoPA.
 
 Section ``riuso``
 ~~~~~~~~~~~~~~~~~

--- a/docs/it/country.rst
+++ b/docs/it/country.rst
@@ -24,7 +24,7 @@ Dunque, se un software è compatibile, troveremo:
    it:
      countryExtensionVersion: "0.2"
      piattaforme:
-        - spid: yes
+        - spid: true 
 
 Nota bene che le chiavi *country-specific* **non** sono valide
 all’interno delle sezioni internazionali. I Paesi che vogliano estendere

--- a/docs/it/example/publiccode.minimal.yml
+++ b/docs/it/example/publiccode.minimal.yml
@@ -41,6 +41,6 @@ maintenance:
     - name: Francesco Rossi
 
 localisation:
-  localisationReady: yes
+  localisationReady: true
   availableLanguages:
     - en

--- a/docs/it/example/publiccode.yml
+++ b/docs/it/example/publiccode.yml
@@ -95,7 +95,7 @@ maintenance:
       phone: +39 231 13215112
 
 localisation:
-  localisationReady: yes
+  localisationReady: true
   availableLanguages:
     - en
     - it
@@ -107,32 +107,32 @@ dependsOn:
     - name: MySQL
       versionMin: "1.1"
       versionMax: "1.3"
-      optional: yes
+      optional: true
     - name: PostgreSQL
       version: "3.2"
-      optional: yes
+      optional: true
   proprietary:
     - name: Oracle
       versionMin: "11.4"
     - name: IBM SoftLayer
   hardware:
     - name: NFC Reader
-      optional: yes
+      optional: true
 
 it:
   countryExtensionVersion: "0.2"
 
   conforme:
-    lineeGuidaDesign: yes
-    modelloInteroperabilita: yes
-    misureMinimeSicurezza: yes
-    gdpr: yes
+    lineeGuidaDesign: true
+    modelloInteroperabilita: true
+    misureMinimeSicurezza: true
+    gdpr: true
 
   piattaforme:
-    spid: yes
-    cie: yes
-    anpr: yes
-    pagopa: yes
+    spid: true
+    cie: true
+    anpr: true
+    pagopa: true
 
   riuso:
     codiceIPA: c_h501

--- a/docs/it/schema.core.rst
+++ b/docs/it/schema.core.rst
@@ -694,7 +694,7 @@ Chiave ``localisation/localisationReady``
 -  Tipo: booleano
 -  Presenza: obbligatoria
 
-Se ``yes``, il software ha l’infrastruttura o è stato progettato per
+Se ``true``, il software ha l’infrastruttura o è stato progettato per
 essere multi-lingua. Ad ogni modo, questo campo non pregiudica
 l’esistenza di una traduzione in altre lingue ma si riferisce
 esclusivamente all’aspetto tecnologico. Per l’elenco delle lingue
@@ -781,7 +781,7 @@ matrice di compatibilità complessa.
 
    - name: PostgreSQL
      version: "3.2"
-     opzionale: yes
+     opzionale: true
 
 Questo snippet segnala una dipendenza opzionale verso PostgreSQL,
 nell’esattezza la sua versione 3.2.

--- a/docs/it/schema.it.rst
+++ b/docs/it/schema.it.rst
@@ -38,7 +38,7 @@ Chiave ``conforme/lineeGuidaDesign``
 -  Tipo: booleano
 -  Presenza: opzionale
 
-Se presente e impostato a ``yes``, il software è conforme alle leggi in
+Se presente e impostato a ``true``, il software è conforme alle leggi in
 materia di accessibilità (L. 4/2004), come descritto ulteriormente nelle
 `linee guida di
 design <https://docs.italia.it/italia/designers-italia/design-linee-guida-docs>`__.
@@ -49,7 +49,7 @@ Chiave ``conforme/modelloInteroperabilita``
 -  Tipo: booleano
 -  Presenza: opzionale
 
-Se presente e impostato a ``yes``, il software è conforme alle `linee
+Se presente e impostato a ``true``, il software è conforme alle `linee
 guida
 sull’interoperabilità <https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs>`__.
 
@@ -62,7 +62,7 @@ Chiave ``conforme/misureMinimeSicurezza``
 -  Tipo: booleano
 -  Presenza: opzionale
 
-Se presente e impostato a ``yes``, il software è conforme alle `Misure
+Se presente e impostato a ``true``, il software è conforme alle `Misure
 minime di sicurezza ICT per le Pubbliche
 amministrazioni <http://www.agid.gov.it/sites/default/files/documentazione/misure_minime_di_sicurezza_v.1.0.pdf>`__.
 
@@ -72,7 +72,7 @@ Chiave ``conforme/gdpr``
 -  Tipo: booleano
 -  Presenza: opzionale
 
-Se presente e impostato a ``yes``, il software rispetta il GDPR.
+Se presente e impostato a ``true``, il software rispetta il GDPR.
 
 Sezione ``piattaforme``
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -83,7 +83,7 @@ Chiave ``piattaforme/spid``
 -  Tipo: booleano
 -  Presenza: opzionale
 
-Se presente e impostato a ``yes``, il software si interfaccia con `SPID
+Se presente e impostato a ``true``, il software si interfaccia con `SPID
 - il Sistema Pubblico di Identità
 Digitale <https://developers.italia.it/it/spid>`__.
 
@@ -93,7 +93,7 @@ Chiave ``piattaforme/cie``
 -  Tipo: booleano
 -  Presenza: opzionale
 
-Se presente e impostato a ``yes``, il software si interfaccia con la
+Se presente e impostato a ``true``, il software si interfaccia con la
 Carta di Identità Elettronica.
 
 Chiave ``piattaforme/anpr``
@@ -102,7 +102,7 @@ Chiave ``piattaforme/anpr``
 -  Tipo: booleano
 -  Presenza: opzionale
 
-Se presente e impostato a ``yes``, il software si interfaccia con ANPR.
+Se presente e impostato a ``true``, il software si interfaccia con ANPR.
 
 Chiave ``piattaforme/pagopa``
 '''''''''''''''''''''''''''''
@@ -110,7 +110,7 @@ Chiave ``piattaforme/pagopa``
 -  Tipo: booleano
 -  Presenza: opzionale
 
-Se presente e impostato a ``yes``, il software si interfaccia con
+Se presente e impostato a ``true``, il software si interfaccia con
 pagoPA.
 
 Sezione ``riuso``


### PR DESCRIPTION
## Title
This PR switches the boolean key values to `true/false` from `yes/no` for compatibility with the latest YAML standard https://yaml.org/spec/1.2/spec.html#id2803629. 
This fixes #8. 
@alranel should we draft a new release? Something like `core-0.3` or `core-0.2.1`?

- [x] Ensure your files are written following RST specs (*not MD!*)
- [x] Italian version
- [x] English version
- [x] Example files 
- [x] Ask for review
