### PR TITLE
Mandate double quotes around phone numbers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,8 @@ All notable changes to this project will be documented in this file.
 Changed
 ~~~~~~~
 
--  Mandates phone numbers to be strings surrounded by double quotes
+-  Phone numbers have to be strings. If it is necessary, they can have double
+   quotes. 
 
 [core-0.2/it-0.2] - 2019-03-13
 ------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,8 +9,7 @@ All notable changes to this project will be documented in this file.
 Changed
 ~~~~~~~
 
--  Phone numbers have to be strings. If it is necessary, they can have double
-   quotes. 
+-  Mandates phone numbers to be strings
 
 [core-0.2/it-0.2] - 2019-03-13
 ------------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+[core-0.2.1] - 2019-10-10
+-------------------------
+
+Changed
+~~~~~~~
+
+-  Mandates phone numbers to be strings surrounded by double quotes
+
 [core-0.2/it-0.2] - 2019-03-13
 ------------------------------
 

--- a/docs/en/example/publiccode.yml
+++ b/docs/en/example/publiccode.yml
@@ -92,7 +92,7 @@ maintenance:
     - name: Francesco Rossi
       email: "francesco.rossi@comune.reggioemilia.it"
       affiliation: Comune di Reggio Emilia
-      phone: +39 231 13215112
+      phone: "+39 231 13215112"
 
 localisation:
   localisationReady: yes

--- a/docs/en/example/publiccode.yml
+++ b/docs/en/example/publiccode.yml
@@ -92,7 +92,7 @@ maintenance:
     - name: Francesco Rossi
       email: "francesco.rossi@comune.reggioemilia.it"
       affiliation: Comune di Reggio Emilia
-      phone: "+39 231 13215112"
+      phone: "+3923113215112"
 
 localisation:
   localisationReady: yes

--- a/docs/en/schema.core.rst
+++ b/docs/en/schema.core.rst
@@ -771,7 +771,7 @@ A Contact is an object with the following properties:
    collection, use ``\x64`` to replace ``@``, as allowed by the YAML
    specification.
 -  ``phone`` - phone number (with international prefix). This has to be
-   a string delimited by double quotes. 
+   a string. 
 -  ``affiliation`` - This key contains an explicit affiliation
    information for the technical contact. In case of multiple
    maintainers, this can be used to create a relation between each

--- a/docs/en/schema.core.rst
+++ b/docs/en/schema.core.rst
@@ -770,7 +770,8 @@ A Contact is an object with the following properties:
    must not be obfuscated. To improve resistance against e-mail
    collection, use ``\x64`` to replace ``@``, as allowed by the YAML
    specification.
--  ``phone`` - phone number (with international prefix)
+-  ``phone`` - phone number (with international prefix). This has to be
+   a string delimited by double quotes. 
 -  ``affiliation`` - This key contains an explicit affiliation
    information for the technical contact. In case of multiple
    maintainers, this can be used to create a relation between each

--- a/docs/it/example/publiccode.yml
+++ b/docs/it/example/publiccode.yml
@@ -92,7 +92,7 @@ maintenance:
     - name: Francesco Rossi
       email: "francesco.rossi@comune.reggioemilia.it"
       affiliation: Comune di Reggio Emilia
-      phone: +39 231 13215112
+      phone: "+39 231 13215112"
 
 localisation:
   localisationReady: yes

--- a/docs/it/example/publiccode.yml
+++ b/docs/it/example/publiccode.yml
@@ -92,7 +92,7 @@ maintenance:
     - name: Francesco Rossi
       email: "francesco.rossi@comune.reggioemilia.it"
       affiliation: Comune di Reggio Emilia
-      phone: "+39 231 13215112"
+      phone: "+3923113215112"
 
 localisation:
   localisationReady: yes

--- a/docs/it/schema.core.rst
+++ b/docs/it/schema.core.rst
@@ -813,7 +813,8 @@ Un Contatto è un oggetto con le seguenti proprietà:
    deve essere offuscato. Per migliorare la resistenza contro la
    raccolta di indirizzi email, usare ``\x64`` per sostituire ``@``,
    siccome questo è permesso dalle specifiche YAML.
--  ``phone`` - Numero telefonico (con prefisso internazionale).
+-  ``phone`` - Numero telefonico (con prefisso internazionale). Questa chiave
+   deve essere una stringa delimitata da doppi apici.
 -  ``affiliation`` - Questa chiave contiene informazioni esplicite sui
    contatti tecnici. Nel caso esistano diversi maintainer, questa chiave
    può essere usata per creare relazioni tra diversi contatti tecnici e

--- a/docs/it/schema.core.rst
+++ b/docs/it/schema.core.rst
@@ -814,7 +814,7 @@ Un Contatto è un oggetto con le seguenti proprietà:
    raccolta di indirizzi email, usare ``\x64`` per sostituire ``@``,
    siccome questo è permesso dalle specifiche YAML.
 -  ``phone`` - Numero telefonico (con prefisso internazionale). Questa chiave
-   deve essere una stringa delimitata da doppi apici.
+   deve essere una stringa.
 -  ``affiliation`` - Questa chiave contiene informazioni esplicite sui
    contatti tecnici. Nel caso esistano diversi maintainer, questa chiave
    può essere usata per creare relazioni tra diversi contatti tecnici e


### PR DESCRIPTION
## Content

This PR mandates to insert the phone number as a string. As such, it mandates to explicitly insert double quotes around the phone number. 

## Review

- [x] Ensure your files are written following RST specs (*not MD!*)
- [x] Italian version
- [x] English version
- [x] Example files 
- [x] Ask for review
