### PR TITLE
Explicitly state UTF-8 is the only valid encoding.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,14 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+[core-0.2.2] - 2019-12-13
+-------------------------
+
+Changed
+~~~~~~~
+
+-  Mandates UTF-8 as the encoding used.
+
 [core-0.2.1] - 2019-10-10
 -------------------------
 

--- a/docs/en/schema.core.rst
+++ b/docs/en/schema.core.rst
@@ -805,5 +805,9 @@ Dates
 ~~~~~
 
 All dates in ``publiccode.yml`` must follow the format “YYYY-MM-DD”,
-which is one of the ISO8601 allowed encoding. This is the only allowed
-encoding though, so not the full ISO8601 is allowed for the date keys.
+which is one of the ISO8601 allowed formats. This is the only allowed
+format though, so not the full ISO8601 is allowed for the date keys.
+
+Encoding
+~~~~~~~~
+`publiccode.yml` **MUST** be UTF-8 encoded.

--- a/docs/it/schema.core.rst
+++ b/docs/it/schema.core.rst
@@ -849,6 +849,10 @@ Data
 ~~~~
 
 Tutte le date in ``publiccode.yml`` devono aderire al formato
-“YYYY-MM-DD” che è una delle codifiche permesse dal ISO8601. **Nota
-bene:** questa è l’unica codifica permessa, quindi non sono consentiti
+“YYYY-MM-DD” che è una dei formati permessi da ISO8601. **Nota
+bene:** questa è l’unico formato permesso, quindi non sono consentiti
 gli altri formati previsti da ISO8601.
+
+Codifica
+~~~~~~~~
+La codifica di ``publiccode.yml`` **DEVE** essere UTF-8.

--- a/docs/it/schema.core.rst
+++ b/docs/it/schema.core.rst
@@ -850,7 +850,7 @@ Data
 
 Tutte le date in ``publiccode.yml`` devono aderire al formato
 “YYYY-MM-DD” che è uno dei formati permessi da ISO8601. **Nota
-bene:** questa è l’unico formato permesso, quindi non sono consentiti
+bene:** questo è l’unico formato permesso, quindi non sono consentiti
 gli altri formati previsti da ISO8601.
 
 Codifica

--- a/docs/it/schema.core.rst
+++ b/docs/it/schema.core.rst
@@ -849,7 +849,7 @@ Data
 ~~~~
 
 Tutte le date in ``publiccode.yml`` devono aderire al formato
-“YYYY-MM-DD” che è una dei formati permessi da ISO8601. **Nota
+“YYYY-MM-DD” che è uno dei formati permessi da ISO8601. **Nota
 bene:** questa è l’unico formato permesso, quindi non sono consentiti
 gli altri formati previsti da ISO8601.
 


### PR DESCRIPTION
Fixes #76.

Should this warrant a bump to the standard's version? I bet all `publiccode.yml` files out there are already UTF-8 encoded.

## Review

- [x] Ensure your files are written following RST specs (*not MD!*)
- [x] Italian version
- [x] English version
- [x] Example files 
- [x] Ask for review
